### PR TITLE
Update deprecated workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,20 @@
 name: Generate and upload a release assets
 
-on:
-  release:
-    types:
-      - published
-      # - unpublished
-      - created
-      - edited
-      #- deleted
-      - prereleased
-      - released
+on: push
 
 jobs:
   upload:
+    if: startsWith(github.ref, 'refs/tags/')
     name: Upload Artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - run: shell-lib/docker/install_docker.sh
       - run: installer/generate_installer.sh
-      - uses: actions/upload-release-asset@v1
+      - uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: installer/ACH-Zeek.tar
-          # Note: This will fail if the asset already exists 
-          # (e.g. editing a release w/o deleting the existing asset)
-          asset_name: ACH-Zeek.tar
-          asset_content_type: application/x-tar
+          files: installer/ACH-Zeek.tar


### PR DESCRIPTION
Many of our projects have been using `actions/checkout@v2` and `actions/upload-release-asset@v1`. 
- `actions/checkout@v2` uses Node v12, which is set to no longer run on Github Actions runners this summer. 
- `actions/upload-release-asset@v1` is now archive-only, and recommends to use `softprops/action-gh-release@v1` as its replacement.

This PR:
- Upgrades to `actions/checkout@v3`
- Switches to `softprops/action-gh-release@v1`

Whenever a push is made to a tagged commit, the workflow will build and upload the resulting release .tar file(s) to the matching release of the tag. This is a bit more flexible than the previous implementation, where now release generation can be tested prior to pushing to the main branch if needed.